### PR TITLE
Fixed bug re RDF model that causes issues with serialising

### DIFF
--- a/rdflib_microdata.py
+++ b/rdflib_microdata.py
@@ -48,7 +48,7 @@ class MicrodataParser(Parser):
             ns = Namespace(ns + "#")
 
         # type the resource
-        sink.add((s, RDF.type, str(item.itemtype)))
+        sink.add((s, RDF.type, URIRef(item.itemtype)))
 
         # go through each property/value and add triples to the graph
         for item_property, item_values in item.props.items():


### PR DESCRIPTION
fixed error re sink.add((s, RDF.type, URIRef(item.itemtype))) - turns out that RDF/XML only works by accident see http://chatlogs.planetrdf.com/swig/2011-06-12.html#T19-30-45 for background
